### PR TITLE
Use one `base.html` with all code that is shared across pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>File Structure Organizer | {% block title %}{% endblock %}</title>
+        <meta name="viewport" content="width=device-width, intitial-scale=1">
+        
+        <!-- Link to CSS file -->
+        <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    </head>
+    <body>
+        <main>
+            {% block content %}
+            {% endblock %}
+        </main>
+    </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,13 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <title>File Structure Organizer</title>
-        <meta name="viewport" content="width=device-width, intitial-scale=1">
-        
-        <!-- Link to CSS file -->
-        <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
-    </head>
-    <body>
-        <h1>File Structure Organizer</h1>
-    </body>
-</html>
+{% extends "base.html" %}
+{% block title %}Home{% endblock %}
+{% block content %}
+    <h1>File Organizer</h1>
+{% endblock %}


### PR DESCRIPTION
This change greatly reduces the amount of lines of HTML one has to write, by putting all base code (the `header` tag, all the static links, etc.) in one file (`base.html`), and extending that file in all other HTML files.